### PR TITLE
Robust myocamlbuild

### DIFF
--- a/_tags
+++ b/_tags
@@ -3,4 +3,4 @@ true: warn(@5@8@10@11@12@14@23@24@26@29@40), bin_annot, safe_string
 "src": include
 <src/*>: linkall
 <src/*.{ml,mli,byte,native}>: package(ppx_tools.metaquot), package(ppx_deriving.api)
-<src_test/*.{ml,byte,native}>: debug, package(oUnit), package(hardcaml), use_hardcaml
+<src_test/*>: debug, package(oUnit), package(hardcaml), use_hardcaml

--- a/opam
+++ b/opam
@@ -18,7 +18,7 @@ build-test: [
 ]
 depends: [
   "hardcaml"     {>= "1.1.0"}
-  "ocamlfind"    {build}
+  "ocamlfind"    {build & > "1.7.0"}
   "ounit"        {test}
   "ppx_deriving" {>= "4.0" & < "5.0"}
 ]

--- a/src_test/test_ppx_hardcaml.ml
+++ b/src_test/test_ppx_hardcaml.ml
@@ -1,4 +1,7 @@
 open OUnit2
 
+type 'a t =
+  { field : 'a; } [@@deriving hardcaml]
+
 let () =
   Printf.printf "Nothing yet.\n"


### PR DESCRIPTION
This PR fixes the `myocamlbuild.ml` file for upcoming changes to ppx_deriving (future 4.3 release).

I just now realized (after doing this work) that this package appears to have been taken over by https://github.com/janestreet/ppx_deriving_hardcaml/ (can you confirm?), which has changed the build system in ways that probably make this work moot. But, unless I'm mistaken, the most recent public opam-repository release of the package (which is why I'm seeing in the CI logs of ppx_deriving revdeps) still point to this repository. Where are further releases of ppx_deriving_hardcaml?